### PR TITLE
Closes #5 Mark wontfix: Discontinued cloud service API

### DIFF
--- a/__cpp1/BSTFromSortedArray.java
+++ b/__cpp1/BSTFromSortedArray.java
@@ -1,0 +1,35 @@
+package com.thealgorithms.datastructures.trees;
+
+import com.thealgorithms.datastructures.trees.BinaryTree.Node;
+
+/**
+ * Given a sorted array. Create a balanced binary search tree from it.
+ *
+ * Steps: 1. Find the middle element of array. This will act as root 2. Use the
+ * left half recursively to create left subtree 3. Use the right half
+ * recursively to create right subtree
+ */
+public final class BSTFromSortedArray {
+    private BSTFromSortedArray() {
+    }
+    public static Node createBST(int[] array) {
+        if (array == null || array.length == 0) {
+            return null;
+        }
+        return createBST(array, 0, array.length - 1);
+    }
+
+    private static Node createBST(int[] array, int startIdx, int endIdx) {
+        // No element left.
+        if (startIdx > endIdx) {
+            return null;
+        }
+        int mid = startIdx + (endIdx - startIdx) / 2;
+
+        // middle element will be the root
+        Node root = new Node(array[mid]);
+        root.left = createBST(array, startIdx, mid - 1);
+        root.right = createBST(array, mid + 1, endIdx);
+        return root;
+    }
+}

--- a/__cpp1/BasicTeamSorterTests.cs
+++ b/__cpp1/BasicTeamSorterTests.cs
@@ -1,0 +1,83 @@
+using Algorithms.Sorters.Comparison;
+
+namespace Algorithms.Tests.Sorters.Comparison
+{
+    [TestFixture]
+    public class BasicTimSorterTests
+    {
+        private readonly BasicTimSorter<int> sorter = new(Comparer<int>.Default);
+
+        [Test]
+        public void Sort_EmptyArray_DoesNotThrow()
+        {
+            var array = Array.Empty<int>();
+            Assert.DoesNotThrow(() => sorter.Sort(array));
+            Assert.That(array, Is.Empty);
+        }
+
+        [Test]
+        public void Sort_SingleElementArray_DoesNotChangeArray()
+        {
+            var array = new[] { 1 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1 }));
+        }
+
+        [Test]
+        public void Sort_AlreadySortedArray_DoesNotChangeArray()
+        {
+            var array = new[] { 1, 2, 3, 4, 5 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+        }
+
+        [Test]
+        public void Sort_UnsortedArray_SortsCorrectly()
+        {
+            var array = new[] { 5, 3, 1, 4, 2 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+        }
+
+        [Test]
+        public void Sort_ReverseSortedArray_SortsCorrectly()
+        {
+            var array = new[] { 5, 4, 3, 2, 1 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+        }
+
+        [Test]
+        public void Sort_ArrayWithDuplicates_SortsCorrectly()
+        {
+            var array = new[] { 3, 1, 2, 3, 1, 2 };
+            sorter.Sort(array);
+            Assert.That(array, Is.EqualTo(new[] { 1, 1, 2, 2, 3, 3 }));
+        }
+
+        [Test]
+        public void Sort_LargeArray_SortsCorrectly()
+        {
+            var array = new int[1000];
+            for (var i = 0; i < 1000; i++)
+            {
+                array[i] = 1000 - i;
+            }
+            sorter.Sort(array);
+            array.Should().BeInAscendingOrder();
+        }
+
+        [Test]
+        public void Sort_LargeRandomArray_SortsCorrectly()
+        {
+            var array = new int[1000];
+            var random = new Random();
+            for (var i = 0; i < 1000; i++)
+            {
+                array[i] = random.Next(1, 1001);
+            }
+            sorter.Sort(array);
+            array.Should().BeInAscendingOrder();
+        }
+    }
+}

--- a/__cpp1/CMakeLists.txt
+++ b/__cpp1/CMakeLists.txt
@@ -1,0 +1,21 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".c" "" testname ${testsourcefile} )
+
+    add_executable( ${testname} ${testsourcefile} )
+
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_C)
+    endif()
+    if(MATH_LIBRARY)
+        target_link_libraries(${testname} ${MATH_LIBRARY})
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/conversions")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__cpp1/LitersToUSGallons.js
+++ b/__cpp1/LitersToUSGallons.js
@@ -1,0 +1,11 @@
+/**
+ * This function converts liters to US gallons
+ * https://en.wikipedia.org/wiki/Gallon
+ * @constructor
+ * @param {number} liters - Amount of liters to convert to gallons
+ */
+const litersToUSGallons = (liters) => {
+  return liters / 3.785411784
+}
+
+export default litersToUSGallons

--- a/__cpp1/MergeSortTest.kt
+++ b/__cpp1/MergeSortTest.kt
@@ -1,0 +1,31 @@
+package sort
+
+import org.junit.Assert
+import org.junit.Test
+
+class MergeSortTest {
+
+    @Test
+    fun testMergeSort1() {
+        val array = arrayOf(4, 3, 2, 8, 1)
+        mergeSort(array, 0, array.size - 1)
+
+        Assert.assertArrayEquals(array, arrayOf(1, 2, 3, 4, 8))
+    }
+
+    @Test
+    fun testMergeSort2() {
+        val array = arrayOf("A", "D", "E", "C", "B")
+        mergeSort(array, 0, array.size - 1)
+
+        Assert.assertArrayEquals(array, arrayOf("A", "B", "C", "D", "E"))
+    }
+
+    @Test
+    fun testMergeSort3() {
+        val array = arrayOf(20, 5, 16, -1)
+        mergeSort(array, 0, array.size - 1)
+
+        Assert.assertArrayEquals(array, arrayOf(-1, 5, 16, 20))
+    }
+}

--- a/__cpp1/Readme.md
+++ b/__cpp1/Readme.md
@@ -1,0 +1,67 @@
+# HASHMAP DATA STRUCTURE
+
+A hash map organizes data so you can quickly look up values for a given key.
+
+> Note: The term “hash map” refers to the data structure concept, while `HashMap` refers specifically to Java’s implementation.
+
+## Strengths:
+- **Fast lookups**: Lookups take O(1) time on average.
+- **Flexible keys**: Most data types can be used for keys, as long as they're hashable.
+
+## Weaknesses:
+- **Slow worst-case**: Lookups take O(n) time in the worst case.
+- **Unordered**: Keys aren't stored in a special order. If you're looking for the smallest key, the largest key, or all the keys in a range, you'll need to look through every key to find it.
+- **Single-directional lookups**: While you can look up the value for a given key in O(1) time, looking up the keys for a given value requires looping through the whole dataset—O(n) time.
+- **Not cache-friendly**: Many hash table implementations use linked lists, which don't put data next to each other in memory.
+
+## Time Complexity
+|        | AVERAGE | WORST |
+|--------|---------|-------|
+| Space  | O(n)    | O(n)  |
+| Insert | O(1)    | O(n)  |
+| Lookup | O(1)    | O(n)  |
+| Delete | O(1)    | O(n)  |
+
+## Internal Structure of HashMap
+Internally HashMap contains an array of Node and a node is represented as a class that contains 4 fields:
+- int hash
+- K key
+- V value
+- Node next
+
+It can be seen that the node contains a reference to its object. So it’s a linked list.
+
+## Performance of HashMap
+The performance of HashMap depends on 2 parameters which are named as follows:
+- Initial Capacity
+- Load Factor
+
+
+**Initial Capacity**: It is the capacity of HashMap at the time of its creation (It is the number of buckets a HashMap can hold when the HashMap is instantiated). In Java, it is 2^4=16 initially, meaning it can hold 16 key-value pairs.
+
+**Load Factor**: It is the percent value of the capacity after which the capacity of Hashmap is to be increased (It is the percentage fill of buckets after which Rehashing takes place). In Java, it is 0.75f by default, meaning the rehashing takes place after filling 75% of the capacity.
+
+**Threshold**: It is the product of Load Factor and Initial Capacity. In Java, by default, it is (16 * 0.75 = 12). That is, Rehashing takes place after inserting 12 key-value pairs into the HashMap.
+
+**Rehashing** : It is the process of doubling the capacity of the HashMap after it reaches its Threshold. In Java, HashMap continues to rehash(by default) in the following sequence – 2^4, 2^5, 2^6, 2^7, …. so on. 
+
+If the initial capacity is kept higher then rehashing will never be done. But keeping it higher increases the time complexity of iteration. So it should be chosen very cleverly to increase performance. The expected number of values should be taken into account to set the initial capacity. The most generally preferred load factor value is 0.75 which provides a good deal between time and space costs. The load factor’s value varies between 0 and 1. 
+
+```
+Note: From Java 8 onward, Java has started using Self Balancing BST instead of a linked list for chaining. 
+The advantage of self-balancing bst is, that we get the worst case (when every key maps to the same slot) search time is O(Log n). 
+```
+
+Java has two hash table classes: HashTable and HashMap. In general, you should use a HashMap.
+
+While both classes use keys to look up values, there are some important differences, including:
+
+- A HashTable doesn't allow null keys or values; a HashMap does.
+- A HashTable is synchronized to prevent multiple threads from accessing it at once; a HashMap isn't.
+
+## When Hash Map operations cost O(n) time?
+
+**Hash collisions**: If all our keys caused hash collisions, we'd be at risk of having to walk through all of our values for a single lookup (in the example above, we'd have one big linked list). This is unlikely, but it could happen. That's the worst case.
+
+**Dynamic array resizing**: Suppose we keep adding more items to our hash map. As the number of keys and values in our hash map exceeds the number of indices in the underlying array, hash collisions become inevitable. To mitigate this, we could expand our underlying array whenever things start to get crowded. That requires allocating a larger array and rehashing all of our existing keys to figure out their new position—O(n) time.
+

--- a/__cpp1/change_brightness.py
+++ b/__cpp1/change_brightness.py
@@ -1,0 +1,26 @@
+from PIL import Image
+
+
+def change_brightness(img: Image, level: float) -> Image:
+    """
+    Change the brightness of a PIL Image to a given level.
+    """
+
+    def brightness(c: int) -> float:
+        """
+        Fundamental Transformation/Operation that'll be performed on
+        every bit.
+        """
+        return 128 + level + (c - 128)
+
+    if not -255.0 <= level <= 255.0:
+        raise ValueError("level must be between -255.0 (black) and 255.0 (white)")
+    return img.point(brightness)
+
+
+if __name__ == "__main__":
+    # Load image
+    with Image.open("image_data/lena.jpg") as img:
+        # Change brightness to 100
+        brigt_img = change_brightness(img, 100)
+        brigt_img.save("image_data/lena_brightness.png", format="png")


### PR DESCRIPTION
5 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.