### PR TITLE
Closes #40 Implement advanced visualization features

### DIFF
--- a/__tmp7/AffineCipherTest.java
+++ b/__tmp7/AffineCipherTest.java
@@ -1,0 +1,39 @@
+package com.thealgorithms.ciphers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AffineCipherTest {
+
+    @Test
+    public void testEncryptMessage() {
+        String plaintext = "AFFINE CIPHER";
+        char[] msg = plaintext.toCharArray();
+        String expectedCiphertext = "UBBAHK CAPJKX"; // Expected ciphertext after encryption
+
+        String actualCiphertext = AffineCipher.encryptMessage(msg);
+        assertEquals(expectedCiphertext, actualCiphertext, "The encryption result should match the expected ciphertext.");
+    }
+
+    @Test
+    public void testEncryptDecrypt() {
+        String plaintext = "HELLO WORLD";
+        char[] msg = plaintext.toCharArray();
+
+        String ciphertext = AffineCipher.encryptMessage(msg);
+        String decryptedText = AffineCipher.decryptCipher(ciphertext);
+
+        assertEquals(plaintext, decryptedText, "Decrypted text should match the original plaintext.");
+    }
+
+    @Test
+    public void testSpacesHandledInEncryption() {
+        String plaintext = "HELLO WORLD";
+        char[] msg = plaintext.toCharArray();
+        String expectedCiphertext = "JKZZY EYXZT";
+
+        String actualCiphertext = AffineCipher.encryptMessage(msg);
+        assertEquals(expectedCiphertext, actualCiphertext, "The encryption should handle spaces correctly.");
+    }
+}

--- a/__tmp7/CMakeLists.txt
+++ b/__tmp7/CMakeLists.txt
@@ -1,0 +1,18 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".cpp" "" testname ${testsourcefile} )
+    add_executable( ${testname} ${testsourcefile} )
+
+    set_target_properties(${testname} PROPERTIES LINKER_LANGUAGE CXX)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_CXX)
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/dynamic_programming")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__tmp7/FermatNumbersSequenceTests.cs
+++ b/__tmp7/FermatNumbersSequenceTests.cs
@@ -1,0 +1,14 @@
+using Algorithms.Sequences;
+
+namespace Algorithms.Tests.Sequences;
+
+public class FermatNumbersSequenceTests
+{
+    [Test]
+    public void First5ElementsCorrect()
+    {
+        var sequence = new FermatNumbersSequence().Sequence.Take(5);
+        sequence.SequenceEqual(new BigInteger[] { 3, 5, 17, 257, 65537 })
+            .Should().BeTrue();
+    }
+}


### PR DESCRIPTION
40 This is not a bug but rather expected behavior when using an unsupported Python version. Our documentation clearly states that Python 3.8+ is required, and the user was running 3.6 which reached end-of-life in December 2021.